### PR TITLE
Fix id lookup on bad rank

### DIFF
--- a/master/flock_server/static/flock.js
+++ b/master/flock_server/static/flock.js
@@ -441,6 +441,12 @@ flock.getId = async function(comm, rank) {
         
         let destId = await flock.getId(comm, dest);
         
+        if (destId.err) {
+            console.error(destId.err);
+            reject(destId.err);
+            return;
+        }
+        
         easyrtc.sendData(destId, MSG_TYPE_MSG, msg, ()=>{});
         
         let interval = setInterval(async () => {

--- a/project_service/app.js
+++ b/project_service/app.js
@@ -134,7 +134,6 @@ const SESSION_SECRET = process.env['FLOCK_SESSION_SECRET'];
                     // if sid corresponds to a rank in the map already, update the easyrtcid
                     Object.assign(commMap[rank], {id: easyrtcid});
                 } else {
-                    // TODO create a variable that accurately tracks number of nodes connected to a comm group
                     // if rank for sid not in map, make a new entry for this new sid
                     commMap[Object.keys(commMap).length] = {id: easyrtcid, sid: sid};
                 }
@@ -202,9 +201,14 @@ const SESSION_SECRET = process.env['FLOCK_SESSION_SECRET'];
             }
             
             if (msg.msgType === MSG_TYPE_GET_ID) {
-                let id = idsByRank[msg.msgData.comm][msg.msgData.rank].id;
+                let result;
+                if (idsByRank[msg.msgData.comm] && idsByRank[msg.msgData.comm][msg.msgData.rank]) {
+                    result = idsByRank[msg.msgData.comm][msg.msgData.rank].id;
+                } else {
+                    result = {err: 'Rank does not exist'};
+                }
                 
-                socketCallback({msgType: MSG_TYPE_GET_ID, msgData: id});
+                socketCallback({msgType: MSG_TYPE_GET_ID, msgData: result});
             }
             
             // continue the chain

--- a/project_service/test/flock-tests/laps.js
+++ b/project_service/test/flock-tests/laps.js
@@ -26,14 +26,9 @@ async function main() {
         
         // send from a to a+1
         if (rank == a) {
-            mpi.isend(a, next, 'default');
-            
-            console.log(`sent to next: ${next}`);
-            
+            console.log(`sent to next with status: ${await mpi.isend(a, next, 'default')}`);
         } else if (rank == next) {
-            mpi.irecv(a, 'default');
-            
-            console.log(`received from a: ${a}`);
+            console.log(`received from a: ${await mpi.irecv(a, 'default')}`);
         }
         
         a = next;


### PR DESCRIPTION
Adds an error message when getId is called with a bad destination rank value. The resulting promise will be rejected with an error message and the same message with be passed to `console.error` (client side)