### PR TITLE
Fix rank 0 id and rank lookup caching

### DIFF
--- a/master/flock_server/static/flock.js
+++ b/master/flock_server/static/flock.js
@@ -698,7 +698,7 @@ flock.awaitClusterSize = async function(size) {
 flock.getRank = async function(comm, ignoreCache=false) {
     
     // check the cache
-    if (!ignoreCache && flock.rank[comm]) {
+    if (!ignoreCache && typeof flock.rank[comm] === 'number') {
         return flock.rank[comm];
     }
     
@@ -738,7 +738,7 @@ flock.getSize = function(comm) {
 flock.getId = async function(comm, rank, ignoreCache=false) {
     
     // check the cache
-    if (!ignoreCache && flock.easyrtcIdByRank[comm][rank]) {
+    if (!ignoreCache && typeof flock.easyrtcIdByRank[comm][rank] === 'string') {
         return flock.easyrtcIdByRank[comm][rank];
     }
     
@@ -747,8 +747,10 @@ flock.getId = async function(comm, rank, ignoreCache=false) {
         (msgType, msgData) => {
             if (MSG_TYPE_GET_ID === msgType) {
                 
-                // cache the id for this rank in this comm
-                flock.easyrtcIdByRank[comm][rank] = msgData;
+                // cache the id for this rank in this comm if lookup was successful
+                if (typeof msgData === 'string') {
+                    flock.easyrtcIdByRank[comm][rank] = msgData;
+                }
                 
                 resolve(msgData);
             } 


### PR DESCRIPTION
When getting the id if the cache contained `0`, counted as a cache miss. This means rank lookup for 0 always missed the cache and went to the project_service.

Fixed this by checking the type of the cached value is `number` (rather than null or undefined)